### PR TITLE
Correct getDevicesByNodeId(Integer) to work with >= 128

### DIFF
--- a/src/main/java/de/fh_zwickau/informatik/sensor/model/devices/DeviceList.java
+++ b/src/main/java/de/fh_zwickau/informatik/sensor/model/devices/DeviceList.java
@@ -76,7 +76,7 @@ public class DeviceList {
 
         for (Device device : mDevices) {
             Integer nodeId = device.getNodeId();
-            if (nodeId != -1) {
+            if (nodeId.intValue() != -1) {
                 if (physicalDevices.containsKey(nodeId)) {
                     physicalDevices.get(nodeId).add(device);
                 } else {
@@ -99,7 +99,7 @@ public class DeviceList {
         Map<Integer, List<Device>> physicalDevice = new HashMap<Integer, List<Device>>();
 
         for (Device device : mDevices) {
-            if (nodeId == device.getNodeId()) {
+            if (nodeId.intValue() == device.getNodeId().intValue()) {
                 if (physicalDevice.containsKey(nodeId)) {
                     physicalDevice.get(nodeId).add(device);
                 } else {


### PR DESCRIPTION
The original solution only works as long as the node is < 128

There might be more places, where this is a problem, but this is the first point where I've run into

Integer comparison with `==` only works if the value is within the range [-128;127]
Anyhow it should be never done